### PR TITLE
More readable/efficient string formatting

### DIFF
--- a/daigle_dist/Binomialdistribution.py
+++ b/daigle_dist/Binomialdistribution.py
@@ -162,5 +162,4 @@ class Binomial(Distribution):
         Returns:
             string: characteristics of the Gaussian
         """
-        representation = "mean {}, standard deviation {}, p {}, n {}".\
-            format(self.mean, self.stdev, self.p, self.n)
+        representation = f"mean {self.mean}, standard deviation {self.stdev}, p {self.p}, n {self.n}"

--- a/daigle_dist/Gaussiandistribution.py
+++ b/daigle_dist/Gaussiandistribution.py
@@ -178,4 +178,4 @@ class Gaussian(Distribution):
 		
 		"""
 		
-		return "mean {}, standard deviation {}".format(self.mean, self.stdev)
+		return f"mean {self.mean}, standard deviation {self.stdev}"


### PR DESCRIPTION
Improved string formatting, more efficient and more readable.

Can add: !r to formatted string to force the use of __repr__ over __str__

Ex: f"{mean}" versus f"{mean!r}"